### PR TITLE
fix display code in Organization-BigBox.json

### DIFF
--- a/fsh/PharmacyExamples.fsh
+++ b/fsh/PharmacyExamples.fsh
@@ -37,7 +37,7 @@ Usage: #example
 * language = #en-US
 * active = true
 * name = "BigBox"
-* type = OrgTypeCS#bus "Non-Healthcare business"
+* type = OrgTypeCS#bus "Non-Healthcare Business"
 * name = "Big Box Retailer"
 * telecom[0].system = #phone
 * telecom[0].value = "(111)-222-3333"


### PR DESCRIPTION
The CodeSystem doesn't indicate whether is caseSensitive or not, but its best to have the right casing in examples